### PR TITLE
reverting error message for BivariateNormal

### DIFF
--- a/symbulate/distributions.py
+++ b/symbulate/distributions.py
@@ -637,8 +637,6 @@ class BivariateNormal(MultivariateNormal):
                             "between -1 and 1.")
 
         self.mean = [mean1, mean2]
-        if (var1 < 0) or (var2 < 0):
-            raise Exception("Variance cannot be less than 0")
 
         if var1 is None:
             var1 = sd1 ** 2


### PR DESCRIPTION
This error message breaks BivariateNormal. If the user specifies sd1 and sd2 instead of var1 and var2, then var1 and var2 are None. Python throws an error when you try to compare None to 0.

Can you please review this pull request, merge it, and then submit a new pull request fixing the problem?