### PR TITLE
Multivariate normal

### DIFF
--- a/symbulate/distributions.py
+++ b/symbulate/distributions.py
@@ -580,17 +580,9 @@ class MultivariateNormal(Distribution):
             raise Exception("The dimension of the mean vector" +
                             "is not compatible with the dimensions" +
                             "of the covariance matrix.")
-        
-        if len(mean) >= 1:
-            if (all (len(row) == len(mean) for row in mean)):
-                self.mean = mean
-            else:
-                raise Exception("Mean matrix is not square")
-        else:
-            raise Exception("Dimension of mean matrix cannot be less than 1")    
-        
+                
         if len(cov) >= 1:
-            if (all (len(row) == len(mean) for row in mean)):
+            if (all(len(row) == len(mean) for row in cov)):
                 self.cov = cov
             else:
                 raise Exception("Cov matrix is not square")

--- a/symbulate/distributions.py
+++ b/symbulate/distributions.py
@@ -637,8 +637,6 @@ class BivariateNormal(MultivariateNormal):
                             "between -1 and 1.")
 
         self.mean = [mean1, mean2]
-        if (var1 < 0) or (var2 < 0):
-            raise Exception("Variance cannot be less than 0")
 
         if var1 is None:
             var1 = sd1 ** 2


### PR DESCRIPTION
The mean parameter of a MultivariateNormal is a vector, not a matrix. So the error check you added here was incorrect.

Please refer to the Symbulate documentation for instructions on how to use the MultivariateNormal function. Also, read the [Wikipedia entry](https://en.wikipedia.org/wiki/Multivariate_normal_distribution) on the multivariate normal distribution. It is crucial that you understand this.