### PR TITLE
add binder badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # Symbulate
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dlsun/symbulate/master?filepath=docs/)
+
 *Symbulate* is a Python package which provides a user friendly
  framework for specifying and conducting simulations from probability models.
 
@@ -18,3 +20,5 @@ command `pip install symbulate` at the command line.
 # Documentation
 
 Please see the [documentation](https://dlsun.github.io/symbulate/index.html) for examples of how to use Symbulate.
+
+Or try live examples with [Binder](https://mybinder.org/v2/gh/dlsun/symbulate/master?filepath=docs/)


### PR DESCRIPTION
Here's a Binder badge for symbulate (test it out if you like): [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dlsun/symbulate/master?filepath=docs/)

This is a proof on concept. You may want to consider separating your notebooks and documentation to make it easier for users to move between notebooks.