### PR TITLE
Add a __repr__ to the Results class

### DIFF
--- a/symbulate/results.py
+++ b/symbulate/results.py
@@ -264,6 +264,44 @@ class Results(Arithmetic, Statistical, Comparable,
                         "probability space. You must first define a RV "
                         "on your probability space and simulate it. "
                         "Then call .plot() on those simulations.")
+        
+    def __repr__(self):
+
+        i_last = len(self) - 1
+        max_index_length = len(str(i_last))
+
+        if max_index_length <= 5:
+            index_header_space = ''
+            index_value_space = ' ' * 4
+        else:
+            index_header_space = ' ' * (max_index_length - 5)
+            index_value_space = ' ' * (max_index_length - 1)
+
+        table_rows = []
+
+        table_rows.append(f"Index{index_header_space} Result")
+
+        for i, result in enumerate(self.results):
+            table_rows.append(f"{str(i)}{index_value_space} {str(result)}")
+
+            if len(self) > 9 and i >= 8:
+                index_value_space = ' ' * (5 - len(str(i_last)))
+
+                if len(self) > 11:
+                    table_rows.append(
+                        f"{'.' * max_index_length}{index_value_space} "
+                        f"{'.' * len(str(self.get(i_last)))}")
+                elif len(self) == 11:
+                    table_rows.append(
+                        f"{str(i_last - 1)}{' ' * (5 - len(str(i_last - 1)))} "
+                        f"{str(self.get(i_last - 1))}")
+
+                table_rows.append(
+                    f"{str(i_last)}{index_value_space} {str(self.get(i_last))}"
+                )
+                break
+
+        return '\n'.join(table_rows)
 
     def _repr_html_(self):
 


### PR DESCRIPTION
This pull request implements `__repr__` for the `Results` class to display simulation results in a formatted table.

This is slightly more complex than what I originally had in mind, but I tried to make the table look good for every case (<9 simulations, 10 simulations, 11 simulations, and 12+ simulations), which may not be necessary. I have some examples and explanations below.

I used f-strings for conciseness and readability, but I think they were introduced in Python 3.6, so something else could be used if that's a problem. Python 3.5 is approaching [end of support on 2020-09-13](https://www.python.org/downloads/) though.

I'm assuming that Index values always start at 0 and count up by 1, since I didn't see any Index columns in the documentation that were different. If this is not the case, `max_index_length`, `index_value_space` and `index_header_space` may need to be calculated differently.

## Before

```
>>> RV(Binomial(4, 0.5)).sim(10)
<symbulate.results.RVResults object at ...>
```

## Examples

When fewer than 10 values are simulated, it doesn't display the last row twice, which Symbulate seems to do in a Jupyter Notebook.

```
>>> RV(Binomial(4, 0.5)).sim(9)
Index Result
0     3
1     3
2     2
3     1
4     2
5     1
6     2
7     4
8     2
```

When 10 values are simulated, it goes directly from index 8 to index 9 without displaying any periods between index 8 and 9. Symbulate currently seems to display periods between index 8 and 9 in a Jupyter Notebook for `.sim(10)`.

```
>>> RV(Binomial(4, 0.5)).sim(10)
Index Result
0     1
1     0
2     3
3     1
4     3
5     3
6     1
7     2
8     3
9     4
```

11 values are simulated here, so if the first 9 rows (index 0-8) and a period row are both displayed before the last row (index 10), the period row would only point to one row (index 9). It's probably uncommon to do exactly 11 simulations, but I thought that it would be better to just display the values in this case, since it displays the same number of rows.

```
>>> RV(Binomial(4, 0.5)).sim(11)
Index Result
0     2
1     0
2     2
3     1
4     3
5     3
6     3
7     2
8     1
9     3
10    1
```

If there are more than 11 values simulated, the values after index 8 and before the last index are displayed as `..`.

```
>>> RV(Binomial(4, 0.5)).sim(12)
Index Result
0     2
1     2
2     3
3     2
4     0
5     2
6     2
7     2
8     4
..    .
11    2
```

The number of periods is equal to the number of digits of the last index.

```
>>> RV(Binomial(4, 0.5)).sim(1000)
Index Result
0     1
1     3
2     3
3     1
4     2
5     1
6     2
7     2
8     4
...   .
999   2
```

```
>>> RV(Binomial(4, 0.5)).sim(100000)
Index Result
0     2
1     1
2     2
3     2
4     4
5     4
6     3
7     3
8     3
..... .
99999 3
```

If the number of digits for the last index value is greater than the number of characters of 'Index', spaces are inserted between "Index" and "Result" to align the columns.

```
>>> RV(Binomial(20, 0.5)).sim(1000000)
Index  Result
0      11
1      12
2      7
3      11
4      10
5      9
6      14
7      9
8      7
...... .
999999 9
```

The number of periods for the Result column is also determined from the number of characters in the last row.

```
>>> cards = ['clubs', 'diamonds', 'hearts', 'spades'] * 13
>>> FirstCard, SecondCard, ThirdCard = RV(BoxModel(cards, size=3, replace=False))
>>> (FirstCard & SecondCard & ThirdCard | ((FirstCard == 'hearts') & (SecondCard == 'hearts')) ).sim(100000)
Index Result
0     (hearts, hearts, clubs)
1     (hearts, hearts, spades)
2     (hearts, hearts, hearts)
3     (hearts, hearts, spades)
4     (hearts, hearts, clubs)
5     (hearts, hearts, clubs)
6     (hearts, hearts, hearts)
7     (hearts, hearts, hearts)
8     (hearts, hearts, diamonds)
..... ........................
99999 (hearts, hearts, spades)
```
```
>>> DeckOfCards(size=5).sim(12)
Index Result
0     ((4, 'Spades'), ('A', 'Clubs'), (10, 'Spades'), ('J', 'Diamonds'), (10, 'Clubs'))
1     (('Q', 'Spades'), (4, 'Diamonds'), (4, 'Spades'), (2, 'Diamonds'), ('A', 'Hearts'))
2     ((5, 'Diamonds'), ('J', 'Diamonds'), (7, 'Diamonds'), ('Q', 'Clubs'), (8, 'Clubs'))
3     ((5, 'Hearts'), ('A', 'Clubs'), (9, 'Hearts'), ('A', 'Spades'), ('A', 'Diamonds'))
4     (('J', 'Clubs'), (9, 'Spades'), (9, 'Diamonds'), (2, 'Clubs'), ('J', 'Diamonds'))
5     ((10, 'Spades'), (2, 'Hearts'), (6, 'Hearts'), (8, 'Spades'), ('Q', 'Diamonds'))
6     ((9, 'Spades'), ('A', 'Clubs'), (10, 'Spades'), ('J', 'Spades'), ('A', 'Spades'))
7     ((3, 'Hearts'), ('Q', 'Clubs'), (6, 'Clubs'), (9, 'Clubs'), (7, 'Clubs'))
8     ((5, 'Clubs'), (8, 'Spades'), ('K', 'Clubs'), (5, 'Hearts'), ('J', 'Hearts'))
..    ...............................................................................
11    (('J', 'Clubs'), (10, 'Diamonds'), (7, 'Spades'), (9, 'Hearts'), (5, 'Hearts'))
```

I added the following code right before the return statement to see if the correct results were displayed, and each result seemed correct in the simulations I tried.

```python
for i, result in enumerate(self.results):
    table_rows.append(f"{str(i)} {str(result)}")
```

## Design

Both columns are left aligned. The first 9 rows and the last row of the table is displayed, following the format of the `_repr_html_` method.

Some changes that I considered but didn't include for now:
- Make the columns right-aligned
- Limit the number of periods printed
- Get the number of periods for the Result column by comparing the lengths for the very last index and the index before that and choose the one with the greater length
- Replace periods with another character such as `-`