### PR TITLE
Add a __repr__ to the Table class for tabulate

### DIFF
--- a/symbulate/table.py
+++ b/symbulate/table.py
@@ -51,6 +51,44 @@ class Table(dict, Arithmetic):
             keys = self.outcomes
 
         return keys
+    
+    def __repr__(self):
+        keys = self.ordered_keys()
+        keys_strings = [str(x) for x in keys]
+        max_key_length = len(max(keys_strings, key=len))
+        outcome_colname_length = len('Outcome')
+
+        table_rows = []
+
+        for i, key in enumerate(keys):
+            if len(str(key)) <= outcome_colname_length:
+                outcome_space = ' ' * (outcome_colname_length - len(str(key)))
+            else:
+                outcome_space = ' ' * (max_key_length - len(str(key)))
+            table_rows.append(f"{key}{outcome_space} {self[key]}")
+
+            if i >= 18:
+                last_outcome = str(keys[-1])
+                last_value = str(self[keys[-1]])
+                table_rows.append(f"{'.' * len(last_outcome)}{outcome_space} "
+                                  f"{'.' * len(last_value)}")
+                table_rows.append(f"{last_outcome}{outcome_space} "
+                                  f"{last_value}")
+                break
+
+        if max_key_length <= outcome_colname_length:
+            outcome_header_space = ' '
+            total_row_space = ' ' * (outcome_colname_length - len('Total'))
+        else:
+            outcome_header_space = ' ' * (max_key_length -
+                                          outcome_colname_length + 1)
+            total_row_space = ' ' * (max_key_length - len('Total'))
+
+        total = str(sum(self.values()))
+        table_rows.append(f"{total_row_space}Total {total}")
+        table_rows.insert(0, f"Outcome{outcome_header_space}Value")
+
+        return '\n'.join(table_rows)
 
     def _repr_html_(self):
         keys = self.ordered_keys()

--- a/symbulate/table.py
+++ b/symbulate/table.py
@@ -37,8 +37,8 @@ class Table(dict, Arithmetic):
                     hash_map[outcome] if outcome in hash_map
                     else 0
                 )
-
-    def _repr_html_(self):
+                
+    def ordered_keys(self):
         # get keys in order
         if self.outcomes is None:
             keys = list(self.keys())
@@ -49,6 +49,11 @@ class Table(dict, Arithmetic):
         else:
             # preserve ordering of outcomes, if specified
             keys = self.outcomes
+
+        return keys
+
+    def _repr_html_(self):
+        keys = self.ordered_keys()
 
         # get HTML for table body
         table_body = ""


### PR DESCRIPTION
This pull request implements `__repr__` for the Table class, so that results are displayed in a table when the `tabulate()` method is called. I moved the first 10 lines in the `_repr_html_` into an `ordered_keys` method, so that I could use it for the `__repr__` as well.

I kept the general format from the `_repr_html_`, so the keys should be ordered in the same way and the total should be calculated in the same way.

Both columns are left aligned except for the "Total" text which I made right-aligned.

# Examples

```
>>> P = BoxModel(['H', 'T', 'A', 'B', 'C', 'D', 'E'], size=1, order_matters=True)
>>> P.sim(1000).tabulate(normalize=True)
Outcome Value
A       0.14
B       0.13
C       0.147
D       0.146
E       0.138
H       0.161
T       0.138
  Total 1.0
```

Additional spaces are inserted between the periods when necessary.
```
>>> P = BoxModel(['H', 'T', 'A', 'B', 'C', 'D', 'E'], size=2, order_matters=True)
>>> P.sim(1000).tabulate(normalize=True)
Outcome Value
(A, A)  0.017
(A, B)  0.024
(A, C)  0.021
(A, D)  0.017
(A, E)  0.017
(A, H)  0.017
(A, T)  0.023
(B, A)  0.018
(B, B)  0.017
(B, C)  0.025
(B, D)  0.013
(B, E)  0.015
(B, H)  0.025
(B, T)  0.03
(C, A)  0.014
(C, B)  0.021
(C, C)  0.023
(C, D)  0.023
(C, E)  0.021
......  .....
(T, T)  0.029
  Total 1.0000000000000007
```
Additional spaces are inserted between "Outcome" and "Value" when the length of the outcomes are greater than the length of the column name.
```
>>> P = BoxModel(['H', 'T', 'A', 'B', 'C', 'D', 'E'], size=3, order_matters=True)
>>> P.sim(1000).tabulate(normalize=True)
Outcome   Value
(A, A, A) 0.001
(A, A, B) 0.004
(A, A, C) 0.001
(A, A, D) 0.004
(A, A, E) 0.003
(A, A, H) 0.003
(A, A, T) 0.003
(A, B, A) 0.001
(A, B, B) 0.005
(A, B, C) 0.002
(A, B, D) 0.004
(A, B, H) 0.004
(A, B, T) 0.002
(A, C, A) 0.002
(A, C, B) 0.002
(A, C, C) 0.003
(A, C, D) 0.001
(A, C, E) 0.002
(A, C, H) 0.005
......... .....
(T, T, T) 0.006
    Total 1.0000000000000007
```

The columns are aligned even though "brown" and "orange" have a different length.
```
>>> P = BoxModel(['orange', 'brown', 'yellow'], probs=[0.5, 0.25, 0.25])
>>> P.sim(10000).tabulate(normalize = True)
Outcome Value
brown   0.2523
orange  0.5033
yellow  0.2444
  Total 1.0
```

```
>>> P = BoxModel([1, 2, 5, 10], probs=[0.4, 0.2, 0.3, 0.1])
>>> P.sim(10000).tabulate(normalize=True)
Outcome Value
1       0.4006
2       0.1966
5       0.304
10      0.0988
  Total 1.0
```

```
>>> states = ["cloud", "rain", "sun"]
>>> TransitionMatrix = [[0.3, 0.2, 0.5],
...                    [0.5, 0.3, 0.2],
...                    [0.3, 0.0, 0.7]]
>>> InitialDistribution = [0, 0, 1] # sunny on Sunday
>>> X = MarkovChain(TransitionMatrix, InitialDistribution, states)
>>> X[5].sim(10000).tabulate(normalize = True)
Outcome Value
cloud   0.3235
rain    0.0852
sun     0.5913
  Total 1.0
```

```
>>> (X[5] & X[6]).sim(10000).tabulate(normalize = True)
Outcome        Value
(cloud, cloud) 0.0968
(cloud, rain)  0.0673
(cloud, sun)   0.1571
(rain, cloud)  0.0422
(rain, rain)   0.0284
(rain, sun)    0.0184
(sun, cloud)   0.1798
(sun, sun)     0.41
         Total 0.9999999999999999
```

```
>>> die = list(range(1, 6 + 1))
>>> P = BoxModel(die, size=2)
>>> X = RV(P, sum)
>>> Y = RV(P, max)
>>> (X & Y).sim(10000).tabulate(normalize=True)
Outcome Value
(2, 1)  0.0272
(3, 2)  0.0578
(4, 2)  0.0278
(4, 3)  0.0519
(5, 3)  0.0568
(5, 4)  0.0538
(6, 3)  0.0251
(6, 4)  0.0576
(6, 5)  0.0533
(7, 4)  0.0555
(7, 5)  0.0556
(7, 6)  0.0551
(8, 4)  0.0287
(8, 5)  0.0566
(8, 6)  0.0553
(9, 5)  0.057
(9, 6)  0.0545
(10, 5) 0.0295
(10, 6) 0.0567
....... ......
(12, 6) 0.0277
  Total 0.9999999999999999
```
