### PR TITLE
Improve 2D Density Plot

### DIFF
--- a/symbulate/plot.py
+++ b/symbulate/plot.py
@@ -135,8 +135,8 @@ def make_density2D(x, y, ax):
     density = gaussian_kde(res)
     xmax, xmin = max(x), min(x)
     ymax, ymin = max(y), min(y)
-    Xgrid, Ygrid = np.meshgrid(np.linspace(xmin, xmax, 100),
-                               np.linspace(ymin, ymax, 100))
+    Xgrid, Ygrid = np.meshgrid(np.linspace(xmin, xmax, 25),
+                               np.linspace(ymin, ymax, 25))
     Z = density.evaluate(np.vstack([Xgrid.ravel(), Ygrid.ravel()]))
     den = ax.imshow(Z.reshape(Xgrid.shape), origin='lower', cmap='Blues',
               aspect='auto', extent=[xmin, xmax, ymin, ymax]


### PR DESCRIPTION
This is a simple change so I'm not sure if looks better for every 2D Density plot, but I did try with a few plots and I think it looks better in general.

I tried different values for the grid, and ended up selecting 25 for this commit.

```python
RV(BivariateNormal()).sim(1000).plot('density')
```
#### Before: 100
![1_100](https://user-images.githubusercontent.com/28831863/90835370-49273480-e301-11ea-9c25-d4dd018180d5.png)

#### 50
![1_50](https://user-images.githubusercontent.com/28831863/90835318-2563ee80-e301-11ea-92a0-6e667e78c4a9.png)

#### 35
![1_35](https://user-images.githubusercontent.com/28831863/90835680-16ca0700-e302-11ea-8599-8923a7a57068.png)


#### 30
![1_30](https://user-images.githubusercontent.com/28831863/90835293-0e250100-e301-11ea-8632-9329e2c4b94e.png)

#### 25
![1_25](https://user-images.githubusercontent.com/28831863/90835200-cf8f4680-e300-11ea-87ee-13c8f12aa551.png)





