### PR TITLE
Use tab10 colormap

### DIFF
--- a/symbulate/plot.py
+++ b/symbulate/plot.py
@@ -12,9 +12,11 @@ ylabel = plt.ylabel
 xlim = plt.xlim
 ylim = plt.ylim
 
-def get_next_color(axes):
+def init_color():
     hex_list = [colors.rgb2hex(rgb) for rgb in plt.cm.get_cmap('tab10').colors]
     plt.rcParams["axes.prop_cycle"] = cycler('color', hex_list)
+
+def get_next_color(axes):
     color_cycle = axes._get_lines.prop_cycler
     color = next(color_cycle)["color"]
     return color

--- a/symbulate/plot.py
+++ b/symbulate/plot.py
@@ -1,6 +1,8 @@
 import numpy as np
+import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 from scipy.stats import gaussian_kde
+from cycler import cycler
 
 figure = plt.figure
 
@@ -11,6 +13,8 @@ xlim = plt.xlim
 ylim = plt.ylim
 
 def get_next_color(axes):
+    hex_list = [colors.rgb2hex(rgb) for rgb in plt.cm.get_cmap('tab10').colors]
+    plt.rcParams["axes.prop_cycle"] = cycler('color', hex_list)
     color_cycle = axes._get_lines.prop_cycler
     color = next(color_cycle)["color"]
     return color

--- a/symbulate/results.py
+++ b/symbulate/results.py
@@ -16,7 +16,7 @@ from matplotlib.transforms import Affine2D
 
 from .base import (Arithmetic, Statistical, Comparable,
                    Logical, Filterable, Transformable)
-from .plot import (configure_axes, get_next_color, is_discrete,
+from .plot import (configure_axes, init_color, get_next_color, is_discrete,
                    count_var, compute_density, add_colorbar,
                    setup_ticks, make_tile, make_violin,
                    make_marginal_impulse, make_density2D)
@@ -343,6 +343,7 @@ class RVResults(Results):
 
     def __init__(self, results, sim_id=None):
         super().__init__(results, sim_id)
+        init_color()
         # get type and dimension of the first result, if it exists
         iterresults = iter(self)
         try:


### PR DESCRIPTION
This makes the plots use the tab10 colormap:
https://matplotlib.org/3.2.1/tutorials/colors/colormaps.html#qualitative

The two lines in the `init_color` function needed to be called when RVResults was initialized, or else the very first plot in a Jupyter Notebook would revert to the default colors. I initially had those two lines within the `get_next_color` function, and each time I would run all cells in a jupyter notebook, the very first plot would use blue and green instead of blue and orange.