### PR TITLE
In BoxModel ctor, correct the check when replacement is False and size of draw is set to None or 1

### DIFF
--- a/symbulate/probability_space.py
+++ b/symbulate/probability_space.py
@@ -150,7 +150,7 @@ class BoxModel(ProbabilitySpace):
 
         # If drawing without replacement, check that the number
         # of draws does not exceed the number of tickets in the box.
-        if not self.replace and self.size > len(self.box):
+        if not self.replace and self.size and self.size > len(self.box):
             raise Exception(
                 "Cannot draw more tickets (without replacement) "
                 "than there are tickets in the box."


### PR DESCRIPTION
To reproduce the problem please use the following code snippet

```python
deck = DeckOfCards()
```

Description of the problem/bug:

When `replacement` is set to False and `size` passed it either None or 1 then the below statement 

```python
if not self.replace and self.size > len(self.box):
```

will evaluate to 

```
if True and None > Integer:
```

This results in an error that looks like this:

![image](https://user-images.githubusercontent.com/127006/149023419-41009724-c170-4333-a199-5449a979d037.png)




Hence it is important to protect the evaluation by doing the following 

```
if not self.replace and self.size and self.size > len(self.box):
```





